### PR TITLE
오타 수정, '테이블 목록' 출력 에러 해결

### DIFF
--- a/ENTROPY/boot.py
+++ b/ENTROPY/boot.py
@@ -551,10 +551,10 @@ def analysis_migraion_inoutbound_data(bound, sys_name):
             tables_df = db_conn.query("SHOW TABLES")
 
             st.info(f"{item_caption['inout_connect'][session['LANG']].format(url)}")
-            tables_df.rename(columns={"Tables_in_kaggle": f"{item_caption['inout_table_list'][session['LANG']]}"}, inplace=True)
+            tables_df.rename(columns={"Tables_in_{}".format(MIG_TARGET_DB_NAME): item_caption['inout_table_list'][session['LANG']]}, inplace=True)
             st.dataframe(tables_df, height=150, width=700, hide_index=True)
 
-            taget_tables = tables_df[f"{item_caption['inout_table_list'][session['LANG']]}"].values.tolist()
+            taget_tables = tables_df[item_caption['inout_table_list'][session['LANG']]].values.tolist()
             opt_index = get_IndexofWidget(session["DPM_SESSION"], taget_tables, "MIG_DATA_NAME")
             st.selectbox(label=f"{item_caption['inout_sel_table'][session['LANG']]}",
                          options=taget_tables,

--- a/ENTROPY/multilanguage/multi_lang.py
+++ b/ENTROPY/multilanguage/multi_lang.py
@@ -33,7 +33,7 @@ item_caption={
 'inout_not_db':{'kor':'등록된 DB가 존재하지 않습니다.','eng':'The registered DB does not exist.'},
 'inout_try_conn':{'kor':'DB 등록을 통해 연계를 설정하세요.','eng':'Try establishing a connection through DB registration.'},
 'inout_sel_db':{'kor':'DataBase를 선택하세요','eng':'Select a DataBase'},
-'inout_connect':{'kor':'{}에 연결 완료"','eng':'Connection to {} complete'},
+'inout_connect':{'kor':'{}에 연결 완료','eng':'Connection to {} complete'},
 'inout_table_list':{'kor':'테이블 목록','eng':'List of tables'},
 'inout_sel_table':{'kor':'대상 테이블 선택','eng':'Select the target table'},
 


### PR DESCRIPTION
- multi_lang.py : 오타 수정
- boot.py : 연계>인바운드&아웃바운드>tables 목록 조회 시 '테이블 목록'이 출력되던 에러 해결